### PR TITLE
Fixed and typo on inmport

### DIFF
--- a/src/Carousel/index.md
+++ b/src/Carousel/index.md
@@ -4,7 +4,7 @@ Demo:
 
 ```tsx
 import React from 'react';
-import { Carousel } from 'react-carousel3d';
+import { Carousel } from 'react-carousel3';
 
 const style = {
   width: 297,


### PR DESCRIPTION
On line 7 while importing the package you made an typo: import { Carousel } from 'react-carousel3d'; // u added an d :D import { Carousel } from 'react-carousel3'; // with this it works fine